### PR TITLE
argcompelete: make sure `_python_argcomplete_scan_head()` is called with a file

### DIFF
--- a/xontrib/argcomplete.py
+++ b/xontrib/argcomplete.py
@@ -102,7 +102,7 @@ def python_argcomplete(ctx: CommandContext):
 
     if not args:
         # handle case where script is executed like `./script.py`, `./script.xsh`
-        if os.path.exists(cmd) and _python_argcomplete_scan_head(cmd):
+        if os.path.isfile(cmd) and _python_argcomplete_scan_head(cmd):
             args = [cmd]
 
     if args:


### PR DESCRIPTION
When trying to complete something within the user's path, but also in current directory, The result is `IsADirectoryError` because `_python_argcomplete_scan_head()` is called using a directory.

To reproduce, use:

```shell
mkdir ls
ls<TAB><TAB>
```